### PR TITLE
adjust spacing for barcode printer

### DIFF
--- a/src/components/base-barcode.vue
+++ b/src/components/base-barcode.vue
@@ -43,7 +43,7 @@ watch(
 </script>
 
 <template>
-  <div class="flex flex-col text-center justify-center items-center relative">
+  <div class="flex flex-col text-center justify-center items-center relative text-black">
     <span class="text-9px z-1 leading-none -mb-2" v-if="props.showName">
       <span>{{ props.label.substring(0, 20) }}</span>
     </span>

--- a/src/modules/purchase/routes.ts
+++ b/src/modules/purchase/routes.ts
@@ -4,23 +4,32 @@ import type { RouteLocationNormalized, NavigationGuardNext } from 'vue-router'
 
 export const routes = {
   path: '/purchase',
-  component: () => import('@/layouts/app/app-index.vue'),
   children: [
     {
       path: '',
-      component: () => import('./views/page-index.vue')
+      component: () => import('@/layouts/app/app-index.vue'),
+      children: [
+        {
+          path: '',
+          component: () => import('./views/page-index.vue')
+        },
+        {
+          path: 'create',
+          component: () => import('./views/page-create.vue')
+        },
+        {
+          path: ':id',
+          component: () => import('./views/page-detail.vue')
+        },
+        {
+          path: ':id/barcode',
+          component: () => import('./views/page-barcode.vue')
+        }
+      ]
     },
     {
-      path: 'create',
-      component: () => import('./views/page-create.vue')
-    },
-    {
-      path: ':id',
-      component: () => import('./views/page-detail.vue')
-    },
-    {
-      path: ':id/barcode',
-      component: () => import('./views/page-barcode.vue')
+      path: ':id/barcode/print',
+      component: () => import('./views/page-barcode-print.vue')
     }
   ],
   beforeEnter: async (to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) => {

--- a/src/modules/purchase/views/page-barcode.vue
+++ b/src/modules/purchase/views/page-barcode.vue
@@ -34,15 +34,22 @@ onMounted(async () => {
   }
 })
 
-const width = ref(320)
+const width = ref(420)
 const gapX = ref(4)
-const gapY = ref(4)
+const gapY = ref(32)
 const height = ref(15)
 const showName = ref(true)
 const showCode = ref(true)
 
 const onPrint = () => {
-  window.print()
+  const params = new URLSearchParams({
+    gap_x: gapX.value.toString(),
+    gap_y: gapY.value.toString(),
+    height: height.value.toString(),
+    show_name: (showName.value ? 1 : 0).toString(),
+    show_code: (showCode.value ? 1 : 0).toString()
+  })
+  window.open('barcode/print?' + params.toString(), '_blank', 'width=1280,height=720')
 }
 </script>
 
@@ -53,10 +60,7 @@ const onPrint = () => {
     </div>
     <div class="flex gap-4">
       <div class="flex-1">
-        <div
-          :style="{ width: width + 'px' }"
-          class="main-content-body print:m-0! print:p-0 print:fixed! print:top-0! print:left-0! bg-white"
-        >
+        <div :style="{ width: width + 'px' }" class="main-content-body bg-white py-4">
           <div
             v-if="items"
             class="grid grid-cols-3 text-sm!"
@@ -112,7 +116,7 @@ const onPrint = () => {
           v-model="gapY"
           label="Gap Y"
           :max="100"
-          description="default 4"
+          description="default 32"
         />
         <component :is="BaseCheckbox" v-model="showName" label="Show Name" />
         <component :is="BaseCheckbox" v-model="showCode" label="Show Code" />


### PR DESCRIPTION
## Printer setup
### Make the printer to stop at exactly 1 strips when printing 1-3 barcode.
1. Open printing preferences, go to tab Page Setup
2. Create new page size (stock), leave width as default (101.6mm), set height to 18.2mm.
3. Open tab Stock, set Media Type: Continuous
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/eecd1525-2a99-4324-bdce-c48b54470c04)
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/c150c586-0634-47e9-86b0-7dfea34b3cda)


## Code Changes
### Added page `/purchase/:id/barcode/print`. Opened in new window when clicking Print button
Easier to setup print layout on a blank page.
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/ed51fa6c-8388-4b08-87f0-7ac2398de0c3)


### Adjust barcode color on dark mode

#### Before
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/7f5a27e7-29b2-4330-bff4-4eaf64bf5664)

#### After
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/a3cd1c67-fba3-4988-81c7-bd39ef3bbfca)

