### PR TITLE
Adjustment for print barcode after adding price

### DIFF
--- a/src/components/base-barcode.vue
+++ b/src/components/base-barcode.vue
@@ -47,12 +47,14 @@ watch(
 </script>
 
 <template>
-  <div class="flex flex-col text-center justify-center items-center relative text-black uppercase font-bold">
-    <span class="text-9px z-1 leading-none -mb-2" v-if="props.showName">
+  <div
+    class="flex flex-col text-center justify-center items-center relative text-black uppercase font-bold bg-white w-40 h-81px"
+  >
+    <span class="text-9px z-1 leading-none" v-if="props.showName">
       <span>{{ props.label }}</span>
     </span>
-    <svg ref="barcodeRef" id="barcode" class="z-0"></svg>
-    <div class="flex flex-col text-center -mt-2">
+    <svg ref="barcodeRef" id="barcode" class="z-0 -my-2"></svg>
+    <div class="flex flex-col text-center">
       <div class="text-8px w-full flex justify-between space-x-3 z-1 leading-none" v-if="props.showCode">
         <span>{{ props.value }}</span>
         <span>{{ props.size }} - {{ props.color }}</span>

--- a/src/modules/purchase/views/page-barcode-print.vue
+++ b/src/modules/purchase/views/page-barcode-print.vue
@@ -41,15 +41,15 @@ onMounted(async () => {
     router.push('/404')
   }
 })
-const gapX = ref<number>(Number(route.query.gap_x) ?? 4)
-const gapY = ref<number>(Number(route.query.gap_y) ?? 32)
+const gapX = ref<number>(Number(route.query.gap_x) ?? 0)
+const gapY = ref<number>(Number(route.query.gap_y) ?? 2)
 const height = ref<number>(Number(route.query.height) ?? 15)
 const showName = ref<boolean>(!!Number(route.query.show_name ?? 1))
 const showCode = ref<boolean>(!!Number(route.query.show_code ?? 1))
 </script>
 
 <template>
-  <div class="grid grid-cols-3 px-20px py-16px" :style="{ 'column-gap': gapX + 'px', 'row-gap': gapY + 'px' }">
+  <div class="grid grid-cols-3 w-120 pr-6" :style="{ 'column-gap': gapX + 'px', 'row-gap': gapY + 'px' }">
     <template v-for="item in items" :key="item">
       <template v-for="size in item.size" :key="item + size">
         <template v-for="i in size.quantity" :key="item + size + i">

--- a/src/modules/purchase/views/page-barcode.vue
+++ b/src/modules/purchase/views/page-barcode.vue
@@ -39,9 +39,9 @@ onMounted(async () => {
   }
 })
 
-const width = ref(420)
-const gapX = ref(4)
-const gapY = ref(32)
+const width = ref(480)
+const gapX = ref(0)
+const gapY = ref(2)
 const height = ref(15)
 const showName = ref(true)
 const showCode = ref(true)
@@ -68,7 +68,7 @@ const onPrint = () => {
         <div class="print:hidden! flex flex-col gap-4">
           <button type="button" @click="onPrint" class="btn btn-primary btn-sm btn-block">Print</button>
         </div>
-        <div :style="{ width: width + 'px' }" class="main-content-body bg-white py-4">
+        <div :style="{ width: width + 'px' }" class="main-content-body py-4">
           <div
             v-if="items"
             class="grid grid-cols-3 text-sm!"


### PR DESCRIPTION
## Code changes
1. Adjust print spacing (gapX: 4 -> 0, gapY: 32 -> 2)
2. Hardcode base barcode width and height to maximum. Changing content affecting height will not require to readjust the gapY.
3. Adjust grid to be more like print preview (moved bg-white from grid container to each base barcode)
4. Added pr-6 to grid container to adjust the third column horizontal position to the center.
5. Removed the py-16 from grid container to center vertical, use printer setting instead, screenshot shown below

#### Before
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/a5c60a68-faf7-4102-9120-7ea6fbed3674)
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/6d1156c1-5672-4941-8678-ed9b71fcb63d)


#### After
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/8ec2c6f0-0c75-445d-a405-3256ef7d3387)
![image](https://github.com/iapmyid/dorothy-app/assets/13524958/c02ffd5f-0981-4b1a-8351-698ee1d547ae)


